### PR TITLE
無限ロード機能を無効化

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -53,6 +53,6 @@ class MoviesController < ApplicationController
   end
 
   def set_movies
-    @movies ||= current_user.movies.order(created_at: :desc).page(params[:page])
+    @movies ||= current_user.movies.order(created_at: :desc)
   end
 end

--- a/app/javascript/components/HomeIndexPage.vue
+++ b/app/javascript/components/HomeIndexPage.vue
@@ -71,9 +71,6 @@
 
           </v-row>
         </v-card>
-        <InfiniteLoading spinner="spiral" @infinite="infiniteHandler">
-          <span slot="no-more"></span>
-        </InfiniteLoading>
       </v-row>
     </v-row>
   </v-app>
@@ -81,21 +78,13 @@
 
 <script>
 import axios from 'axios';
-import InfiniteLoading from 'vue-infinite-loading';
 export default {
-  components: { InfiniteLoading },
-  // スクロールしたらinfiniteHandlerをはっかするようにする
-  // mounted () {
-  //   this.infiniteHandler();
-  //   this.$nextTick(function () {
-  //     this.isLoading = false;
-  //   });
-  // },
+  mounted () {
+    this.getMovie();
+  },
   data: function () {
     return {
-      page: 1,
       movies: [],
-       isLoading: true,
     }  
   },
   computed: {
@@ -133,23 +122,15 @@ export default {
     oneDayAfter: function() {
       this.$store.dispatch('oneDayAfter');
     },
-    infiniteHandler($state) {
+    getMovie() {
       axios
-      .get('/movies', {
-        params: { page: this.page },
-      })
+      .get('/movies')
       .then(response => {
-        if (response.data.length) {
-          this.page += 1;
-          this.movies.push(...response.data);
-          this.$store.dispatch('updateStatus');
-          $state.loaded();
-        } else {
-          $state.complete();
-        }
+        this.movies = response.data;
+        this.$store.dispatch('updateStatus');
       })
       .catch(error => {
-        router.push({name: 'LoginForm' })
+        this.$router.push({name: 'LoginForm' })
         console.log(error)
       })
     },


### PR DESCRIPTION
## 行った対応
* 無限ロード機能を無効化

## 対応の背景
とくに無限ロードが必要と感じなかったため。
後々データ数が増えてきたとき、または高頻度で動画を登録する人がいたときに導入する必要があるかもしれないが、今のところ１日の動画の件数が１０件程度のため、無駄にparamsを増やしたりする方が処理重くなる。
